### PR TITLE
Fixed jsWorker URL for production

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -133,8 +133,7 @@ export default new Vuex.Store({
   ],
   actions: {
     runJs(context, {state, code, input}) {
-      let jsWorker = null
-        jsWorker = new Worker('../../static/jsWorker.js')
+      let jsWorker = new Worker('../../static/jsWorker.js')
       input = JSON.stringify(input)
       jsWorker.postMessage({code, input})
       return new Promise((resolve, reject) => {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -134,9 +134,6 @@ export default new Vuex.Store({
   actions: {
     runJs(context, {state, code, input}) {
       let jsWorker = null
-      if (process.env.NODE_ENV === 'production')
-        jsWorker = new Worker('../../ide/static/jsWorker.js')
-      else
         jsWorker = new Worker('../../static/jsWorker.js')
       input = JSON.stringify(input)
       jsWorker.postMessage({code, input})


### PR DESCRIPTION
Earlier ide was deployed at codingblocks.com/ide/ . Fixed the worker url now. Js evaluation is not currently working in prod.
@Prajjwal 
@championswimmer 