### PR TITLE
fixed spacing for Shortcuts button

### DIFF
--- a/src/components/editor/MenuBar.vue
+++ b/src/components/editor/MenuBar.vue
@@ -37,7 +37,7 @@
             </button>
             <share></share>
             <button id="panelLang" type="button" class="btn btn-sm btn-menu" @click="showShortcutsModal()">
-              Shortcuts<i class="fa fa-reply-all" aria-hidden="true"></i>
+              Shortcuts <i class="fa fa-reply-all" aria-hidden="true"></i>
             </button>
           </div>
           <div class="logoMenu">


### PR DESCRIPTION
Fix missing whitespace before `Shortcuts` FA icon.

## Before

![image](https://user-images.githubusercontent.com/25141164/66723268-ac158880-ee1f-11e9-849d-f2f6646bf739.png)


## After

![image](https://user-images.githubusercontent.com/25141164/66723371-d451b700-ee20-11e9-91e4-f17f73a26233.png)
