### PR TITLE
Fixes #338 : Add c# syntax color highlighting

### DIFF
--- a/src/components/editor/MonacoEditor.vue
+++ b/src/components/editor/MonacoEditor.vue
@@ -9,7 +9,7 @@
   const langModes = {
     'c': 'c',
     'cpp': 'cpp',
-    'c#': 'csharp',
+    'csharp': 'csharp',
     'java8': 'java',
     'py2': 'python',
     'py3': 'python',


### PR DESCRIPTION
Fixes #338

<img width="709" alt="fix" src="https://user-images.githubusercontent.com/43447509/82432850-3f95f280-9aae-11ea-9870-d87093d04f60.png">
