### PR TITLE
Closes #313 : Add golang stub & monaco support for 'go'

### DIFF
--- a/src/assets/js/sample-source.js
+++ b/src/assets/js/sample-source.js
@@ -85,7 +85,7 @@ const lang_samples = {
   'ruby': ruby_sample,
   'rust': rust_sample,
   'kotlin': kotlin_sample,
-  'go': go_sample
+  'golang': go_sample
 };
 
 export default lang_samples

--- a/src/assets/js/sample-source.js
+++ b/src/assets/js/sample-source.js
@@ -65,6 +65,12 @@ const rust_sample =
   '  println!("Hello, world!");\n' +
   '}\n';
 
+const go_sample =
+  'package main\n' +
+  'import "fmt"\n' +
+  'func main() {\n' +
+  '  fmt.Println("Hello World!")\n' +
+  '}\n';
 
 const lang_samples = {
   'c': c_sample,
@@ -78,8 +84,8 @@ const lang_samples = {
   'nodejs10': js_sample,
   'ruby': ruby_sample,
   'rust': rust_sample,
-  'kotlin': kotlin_sample
+  'kotlin': kotlin_sample,
+  'go': go_sample
 };
 
 export default lang_samples
-

--- a/src/components/editor/MonacoEditor.vue
+++ b/src/components/editor/MonacoEditor.vue
@@ -18,7 +18,7 @@
     'nodejs10': 'javascript',
     'ruby': 'ruby',
     'kotlin': 'kotlin',
-    'go': 'go',
+    'golang': 'go',
   }
 
   export default {

--- a/src/components/editor/MonacoEditor.vue
+++ b/src/components/editor/MonacoEditor.vue
@@ -17,7 +17,8 @@
     'nodejs8': 'javascript',
     'nodejs10': 'javascript',
     'ruby': 'ruby',
-    'kotlin': 'kotlin'
+    'kotlin': 'kotlin',
+    'go': 'go',
   }
 
   export default {


### PR DESCRIPTION
Closes #313 

- added stub for 'go' lang
- added 'go' lang support in monaco-editor (for syntax color highlighting)

<img width="660" alt="go" src="https://user-images.githubusercontent.com/43447509/82439551-7ec94100-9ab8-11ea-997c-bc569dec61c3.png">
